### PR TITLE
Synchronization Controller and Service

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,4 @@
+# Taco Service 
+[![Build Status](https://travis-ci.org/tolkiana/taco-service.svg?branch=master)](https://travis-ci.org/tolkiana/taco-service)
+
+TacoApp's back-end service

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/product/DefaultProductService.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/product/DefaultProductService.kt
@@ -12,7 +12,7 @@ class DefaultProductService(val resourceService: ResourceService) : ProductServi
     private var products = ConcurrentHashMap<ProductType, List<Product>>()
 
     @PostConstruct
-    fun loadProducts() {
+    override fun loadProducts() {
         ProductType.values().forEach {
             products[it] = resourceService.getProducts(it.file)
         }

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/product/ProductService.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/product/ProductService.kt
@@ -4,5 +4,7 @@ import com.tolkiana.taco.tacoservice.dto.Product
 
 interface ProductService {
 
+    fun loadProducts()
+
     fun getProducts(productType: ProductType): List<Product>
 }

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/recipe/spoonacular/RecipeToProduct.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/recipe/spoonacular/RecipeToProduct.kt
@@ -12,8 +12,8 @@ class RecipeToProduct : Function<Recipe, Product> {
     override fun apply(recipe: Recipe): Product {
         val ingredients = recipe.ingredients
                 .map { it.original }
-        val preparation = recipe.instructions.first().instructions
-                .map { it.action }
+        val instructions = recipe.instructions
+        val preparation = if (instructions.isEmpty()) emptyList() else instructions.first().steps.map { it.action }
         return Product(UUID.randomUUID().toString(), recipe.title, recipe.image, ingredients, preparation)
     }
 }

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/recipe/spoonacular/dto/Instructions.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/recipe/spoonacular/dto/Instructions.kt
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class Instructions(@JsonProperty("steps") val instructions: List<Instruction>)
+data class Instructions(@JsonProperty("steps") val steps: List<Instruction>)

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncController.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncController.kt
@@ -1,0 +1,16 @@
+package com.tolkiana.taco.tacoservice.sync
+
+import com.tolkiana.taco.tacoservice.sync.dto.SyncRequest
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SyncController(val syncService: SyncService) {
+
+    @PostMapping("/sync")
+    fun synchronize(@RequestBody request: SyncRequest): String {
+        syncService.synchronize(request)
+        return "sync'ed!"
+    }
+}

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncService.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncService.kt
@@ -1,0 +1,21 @@
+package com.tolkiana.taco.tacoservice.sync
+
+import com.tolkiana.taco.tacoservice.product.ProductService
+import com.tolkiana.taco.tacoservice.recipe.RecipeService
+import com.tolkiana.taco.tacoservice.resource.ResourceService
+import com.tolkiana.taco.tacoservice.sync.dto.SyncRequest
+import org.springframework.stereotype.Service
+
+@Service
+class SyncService(val resourceService: ResourceService, val recipeService: RecipeService, val productService: ProductService) {
+
+    fun synchronize(request: SyncRequest) {
+        request.sync.forEach {
+            val products = it.products.map {
+                recipeService.searchRecipeForProduct(it.search)
+            }
+            resourceService.uploadProducts(it.file, products)
+            productService.loadProducts()
+        }
+    }
+}

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/ProductRequest.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/ProductRequest.kt
@@ -1,0 +1,8 @@
+package com.tolkiana.taco.tacoservice.sync.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ProductRequest(@JsonProperty("file") val file: String,
+                          @JsonProperty("products") val products: List<ProductSearch>)

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/ProductSearch.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/ProductSearch.kt
@@ -1,0 +1,7 @@
+package com.tolkiana.taco.tacoservice.sync.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ProductSearch(@JsonProperty("search") val search: String)

--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/SyncRequest.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/dto/SyncRequest.kt
@@ -1,0 +1,7 @@
+package com.tolkiana.taco.tacoservice.sync.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SyncRequest(@JsonProperty("sync") val sync: List<ProductRequest>)


### PR DESCRIPTION
In this PR we expose a new endpoint `/sync` in the service, which allows us to request a product synchronization.

This synchronization will override the files in AWS and in the service's local cache.

This is how an example payload looks like:

```
{
  "sync": [
    {
      "file": "tacos.json",
      "products": [
        {
          "search": "Tacos al Pastor"
        },
        {
          "search": "Tacos de Barbacoa"
        },
        {
          "search": "Tacos de Carne Asada"
        },
        {
          "search": "Tacos Cochinita Pibil"
        }
      ]
    },
    {
      "file": "salsas.json",
      "products": [
        {
          "search": "Pico de Gallo Salsa"
        },
        {
          "search": "Salsa Verde"
        },
        {
          "search": "Guacamole Salsa"
        }
      ]
    },
    {
      "file": "drinks.json",
      "products": [
        {
          "search": "Agua Jamaica Hibiscus"
        },
        {
          "search": "Horchata"
        },
        {
          "search": "Lemonade Mexican"
        }
      ]
    }
  ]
}
```