### PR TITLE
Sync Products Endpoint

### DIFF
--- a/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncController.kt
+++ b/src/main/kotlin/com/tolkiana/taco/tacoservice/sync/SyncController.kt
@@ -1,16 +1,23 @@
 package com.tolkiana.taco.tacoservice.sync
 
+import com.tolkiana.taco.tacoservice.product.ProductService
 import com.tolkiana.taco.tacoservice.sync.dto.SyncRequest
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class SyncController(val syncService: SyncService) {
+class SyncController(val syncService: SyncService, val productService: ProductService) {
 
     @PostMapping("/sync")
     fun synchronize(@RequestBody request: SyncRequest): String {
         syncService.synchronize(request)
+        return "sync'ed!"
+    }
+
+    @PostMapping("/sync-products")
+    fun synchronizeLocal(): String {
+        productService.loadProducts()
         return "sync'ed!"
     }
 }


### PR DESCRIPTION
This endpoint allows us to manually modify the JSONs in AWS, then POST /sync-products to re-load them from AWS into the service's cache.